### PR TITLE
fix: remove warnings on latest nightly

### DIFF
--- a/src/bin/debug.rs
+++ b/src/bin/debug.rs
@@ -1,4 +1,3 @@
-#![feature(duration_float)]
 extern crate eyros;
 extern crate failure;
 extern crate random_access_disk;

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -108,7 +108,7 @@ impl<D,P,V> Branch<D,P,V> where D: DataBatch<P,V>, P: Point, V: Value {
       matched: vec![false;blen]
     })
   }
-  pub fn alloc (&mut self, alloc: &mut FnMut (usize) -> u64) -> () {
+  pub fn alloc (&mut self, alloc: &mut dyn FnMut (usize) -> u64) -> () {
     self.offset = alloc(self.bytes());
   }
   fn bytes (&self) -> usize {
@@ -119,7 +119,7 @@ impl<D,P,V> Branch<D,P,V> where D: DataBatch<P,V>, P: Point, V: Value {
       + (n+bf+7)/8 // D
       + (n+bf)*size_of::<u64>() // I+B
   }
-  pub fn build (&mut self, alloc: &mut FnMut (usize) -> u64)
+  pub fn build (&mut self, alloc: &mut dyn FnMut (usize) -> u64)
   -> Result<(Vec<u8>,Vec<Node<D,P,V>>),Error> {
     let order = &self.order;
     let n = order.len();

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -110,6 +110,6 @@ where S: RandomAccess<Error=Error>, P: Point, V: Value {
   }
   pub fn query<'a,'b> (&'a mut self, bbox: &'b P::Bounds)
   -> StagingIterator<'a,'b,P,V> {
-    <(StagingIterator<'a,'b,P,V>)>::new(&self.rows, bbox)
+    <StagingIterator<'a,'b,P,V>>::new(&self.rows, bbox)
   }
 }


### PR DESCRIPTION
Just following compiler recommendations on rustc 1.42.0-nightly (9ed29b6ff 2020-01-29)
